### PR TITLE
Expand DPMM experiments with random kernels and metrics

### DIFF
--- a/paper_examples/esa_dpmm_likelihood_experiment.py
+++ b/paper_examples/esa_dpmm_likelihood_experiment.py
@@ -1,75 +1,64 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
+from utils import compute_and_print_metrics
+
 
 def main():
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    run_id = "esa_dpmm_likelihood_experiment"
-    nasa_segmentator = EsaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-        segments_id="channel_segments"
-    )
-    benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    for model_type in model_types:
+        run_id = f"esa_dpmm_likelihood_{model_type.lower()}"
+        nasa_segmentator = EsaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean", "var", "std", "n_peaks",
+                "smooth10_n_peaks", "smooth20_n_peaks",
+                "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
+            ],
+            segments_id="channel_segments",
+        )
+        benchmark = ESABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-    for mission_wrapper in ESAMissions:
-        mission = mission_wrapper.value
-        if mission.index != 1:
-            continue
-        for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+        for mission_wrapper in ESAMissions:
+            mission = mission_wrapper.value
+            if mission.index != 1:
                 continue
-            detector = DPMMWrapperDetector(
-                mode="likelihood",      # oppure "new_cluster"
-                model_type="Full",
-                K=100,
-                num_iterations=50,
-                lr=0.8,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-            )
+            for channel_id in mission.target_channels:
+                if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
+                    continue
+                detector = DPMMWrapperDetector(
+                    mode="likelihood",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.8,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )
 
-            benchmark.run_classifier(
-                mission=mission,
-                channel_id=channel_id,
-                classifier=detector,
-                callbacks=callbacks,
-                supervised=False
-            )
-            
+                benchmark.run_classifier(
+                    mission=mission,
+                    channel_id=channel_id,
+                    classifier=detector,
+                    callbacks=callbacks,
+                    supervised=False,
+                )
+
         results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
-
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        compute_and_print_metrics(results_df, "esa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/esa_dpmm_new_cluster_experiment.py
+++ b/paper_examples/esa_dpmm_new_cluster_experiment.py
@@ -1,74 +1,64 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
+from utils import compute_and_print_metrics
+
 
 def main():
-    run_id = "esa_dpmm_new_clusters_experiment"
-    nasa_segmentator = EsaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-        segments_id="channel_segments"
-    )
-    benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    for mission_wrapper in ESAMissions:
-        mission = mission_wrapper.value
-        if mission.index != 1:
-            continue
-        for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+    for model_type in model_types:
+        run_id = f"esa_dpmm_new_cluster_{model_type.lower()}"
+        nasa_segmentator = EsaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean", "var", "std", "n_peaks",
+                "smooth10_n_peaks", "smooth20_n_peaks",
+                "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
+            ],
+            segments_id="channel_segments",
+        )
+        benchmark = ESABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
+
+        for mission_wrapper in ESAMissions:
+            mission = mission_wrapper.value
+            if mission.index != 1:
                 continue
-            detector = DPMMWrapperDetector(
-                mode="new_cluster",      # oppure "new_cluster"
-                model_type="Full",
-                K=100,
-                num_iterations=50,
-                lr=0.8,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-            )
+            for channel_id in mission.target_channels:
+                if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
+                    continue
+                detector = DPMMWrapperDetector(
+                    mode="new_cluster",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.8,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )
 
-            benchmark.run_classifier(
-                mission=mission,
-                channel_id=channel_id,
-                classifier=detector,
-                callbacks=callbacks,
-                supervised=False
-            )
-            
+                benchmark.run_classifier(
+                    mission=mission,
+                    channel_id=channel_id,
+                    classifier=detector,
+                    callbacks=callbacks,
+                    supervised=False,
+                )
+
         results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
-
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        compute_and_print_metrics(results_df, "esa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/esa_rocket_dpmm_likelihood_experiment.py
+++ b/paper_examples/esa_rocket_dpmm_likelihood_experiment.py
@@ -1,84 +1,64 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
-
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+from utils import compute_and_print_metrics
+
+
 def main():
-    
-    run_id = "esa_rocket_dpmm_likelihood_experiment"
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    nasa_segmentator = EsaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-        segments_id="channel_segments",
-        save_csv=False
-    )
+    for model_type in model_types:
+        run_id = f"esa_rocket_dpmm_likelihood_{model_type.lower()}"
+        nasa_segmentator = EsaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
+            segments_id="channel_segments",
+            save_csv=False,
+        )
 
-    benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-    for mission_wrapper in ESAMissions:
-        mission = mission_wrapper.value
-        if mission.index != 1:
-            continue
-        for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+        benchmark = ESABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
+
+        for mission_wrapper in ESAMissions:
+            mission = mission_wrapper.value
+            if mission.index != 1:
                 continue
-            base_classifier = DPMMWrapperDetector(
-                mode="likelihood",      # oppure "new_cluster"
-                model_type="Full",
-                K=100,
-                num_iterations=50,
-                lr=0.8,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-            )
-            benchmark.run_classifier(
-                mission=mission,
-                channel_id=channel_id,
-                classifier=RocketClassifier(
-                    base_model=base_classifier,
-                    num_kernels=10
+            for channel_id in mission.target_channels:
+                if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
+                    continue
+                base_classifier = DPMMWrapperDetector(
+                    mode="likelihood",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.8,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )
+                benchmark.run_classifier(
+                    mission=mission,
+                    channel_id=channel_id,
+                    classifier=RocketClassifier(
+                        base_model=base_classifier,
+                        num_kernels=10,
                     ),
-                callbacks=callbacks,
-                supervised=False
-            )
+                    callbacks=callbacks,
+                    supervised=False,
+                )
 
-            
         results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
-
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        compute_and_print_metrics(results_df, "esa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/esa_rocket_dpmm_new_cluster_experiment.py
+++ b/paper_examples/esa_rocket_dpmm_new_cluster_experiment.py
@@ -1,82 +1,63 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
-
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
-def main():
-   
-    run_id = "esa_rocket_dpmm_new_cluster_experiment"
+from utils import compute_and_print_metrics
 
-    nasa_segmentator = EsaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-        segments_id="channel_segments",
-        save_csv=False
-    )
-    benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-    for mission_wrapper in ESAMissions:
-        mission = mission_wrapper.value
-        if mission.index != 1:
-            continue
-        for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+
+def main():
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+
+    for model_type in model_types:
+        run_id = f"esa_rocket_dpmm_new_cluster_{model_type.lower()}"
+        nasa_segmentator = EsaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
+            segments_id="channel_segments",
+            save_csv=False,
+        )
+        benchmark = ESABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
+
+        for mission_wrapper in ESAMissions:
+            mission = mission_wrapper.value
+            if mission.index != 1:
                 continue
-            base_classifier = DPMMWrapperDetector(
-                mode="new_cluster",      # oppure "new_cluster"
-                model_type="Full",
-                K=100,
-                num_iterations=50,
-                lr=0.8,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-            )
-            benchmark.run_classifier(
-                mission=mission,
-                channel_id=channel_id,
-                classifier=RocketClassifier(
-                    base_model=base_classifier,
-                    num_kernels=10
+            for channel_id in mission.target_channels:
+                if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
+                    continue
+                base_classifier = DPMMWrapperDetector(
+                    mode="new_cluster",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.8,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )
+                benchmark.run_classifier(
+                    mission=mission,
+                    channel_id=channel_id,
+                    classifier=RocketClassifier(
+                        base_model=base_classifier,
+                        num_kernels=10,
                     ),
-                callbacks=callbacks,
-                supervised=False
-            )
+                    callbacks=callbacks,
+                    supervised=False,
+                )
 
         results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
-
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        compute_and_print_metrics(results_df, "esa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/esa_rocket_xgboost_experiment.py
+++ b/paper_examples/esa_rocket_xgboost_experiment.py
@@ -1,37 +1,29 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
-
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from xgboost import XGBClassifier
+from utils import compute_and_print_metrics
+
+
 def main():
     run_id = "esa_rocket_xgboost_experiment"
     nasa_segmentator = EsaDatasetSegmentator(
         segment_duration=50,
         step_duration=50,
         extract_features=False,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
         segments_id="channel_segments",
-        save_csv=False
+        save_csv=False,
     )
     benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
+        run_id=run_id,
+        exp_dir="experiments",
         data_root="datasets",
-        segmentator = nasa_segmentator,
+        segmentator=nasa_segmentator,
     )
     callbacks = [SystemMonitorCallback()]
     for mission_wrapper in ESAMissions:
@@ -39,7 +31,7 @@ def main():
         if mission.index != 1:
             continue
         for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+            if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
                 continue
 
             benchmark.run_classifier(
@@ -47,28 +39,14 @@ def main():
                 channel_id=channel_id,
                 classifier=RocketClassifier(
                     base_model=XGBClassifier(),
-                    num_kernels=500
-                    ),
+                    num_kernels=10,
+                ),
                 callbacks=callbacks,
-                supervised=True
+                supervised=True,
             )
-            
-        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
 
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+    compute_and_print_metrics(results_df, "esa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/nasa_dpmm_likelihood_experiment.py
+++ b/paper_examples/nasa_dpmm_likelihood_experiment.py
@@ -1,70 +1,58 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.nasa_segmentator import NasaDatasetSegmentator
+from utils import compute_and_print_metrics
 
 def main():
     
-    run_id = "nasa_dpmm_likelihood_experiment"
-    nasa_segmentator = NasaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-    )
-    benchmark = NASABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    channels = NASA.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        detector = DPMMWrapperDetector(
-            mode="likelihood",      # oppure "new_cluster"
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
+    for model_type in model_types:
+        run_id = f"nasa_dpmm_likelihood_{model_type.lower()}"
+        nasa_segmentator = NasaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean", "var", "std", "n_peaks",
+                "smooth10_n_peaks", "smooth20_n_peaks",
+                "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
+            ],
         )
-
-        benchmark.run_classifier(
-            channel_id,
-            classifier=detector,
-            callbacks=callbacks,
+        benchmark = NASABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
         )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+        callbacks = [SystemMonitorCallback()]
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        channels = NASA.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            detector = DPMMWrapperDetector(
+                mode="likelihood",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.8,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=detector,
+                callbacks=callbacks,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        compute_and_print_metrics(results_df, "nasa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/nasa_dpmm_new_cluster_experiment.py
+++ b/paper_examples/nasa_dpmm_new_cluster_experiment.py
@@ -1,70 +1,58 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.nasa_segmentator import NasaDatasetSegmentator
+from utils import compute_and_print_metrics
 
 def main():
     
-    run_id = "nasa_dpmm_new_cluster_experiment"
-    nasa_segmentator = NasaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-    )
-    benchmark = NASABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    channels = NASA.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        detector = DPMMWrapperDetector(
-            mode="new_cluster",      # oppure "new_cluster"
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
+    for model_type in model_types:
+        run_id = f"nasa_dpmm_new_cluster_{model_type.lower()}"
+        nasa_segmentator = NasaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean", "var", "std", "n_peaks",
+                "smooth10_n_peaks", "smooth20_n_peaks",
+                "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
+            ],
         )
-
-        benchmark.run_classifier(
-            channel_id,
-            classifier=detector,
-            callbacks=callbacks,
+        benchmark = NASABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
         )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+        callbacks = [SystemMonitorCallback()]
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        channels = NASA.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            detector = DPMMWrapperDetector(
+                mode="new_cluster",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.8,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=detector,
+                callbacks=callbacks,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        compute_and_print_metrics(results_df, "nasa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/nasa_rocket_dpmm_experiment.py
+++ b/paper_examples/nasa_rocket_dpmm_experiment.py
@@ -1,65 +1,55 @@
 import os
 import pandas as pd
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.segmentators.nasa_segmentator import NasaDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
-def main():
-    return
-    run_id = "nasa_rocket_dpmm"
-    nasa_segmentator = NasaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-    )
-    benchmark = NASABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-    channels = NASA.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        base_classifier = DPMMWrapperDetector(
-            mode="likelihood",      # oppure "new_cluster"
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-        )
-        benchmark.run_classifier(
-            channel_id,
-            classifier=RocketClassifier(
-                base_model=base_classifier,
-                num_kernels=50
-                ),
-            callbacks=callbacks,
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+from utils import compute_and_print_metrics
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+
+def main():
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+
+    for model_type in model_types:
+        run_id = f"nasa_rocket_dpmm_{model_type.lower()}"
+        nasa_segmentator = NasaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
+        )
+        benchmark = NASABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
+        channels = NASA.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            base_classifier = DPMMWrapperDetector(
+                mode="likelihood",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.8,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+            benchmark.run_classifier(
+                channel_id,
+                classifier=RocketClassifier(
+                    base_model=base_classifier,
+                    num_kernels=50,
+                ),
+                callbacks=callbacks,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        compute_and_print_metrics(results_df, "nasa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/nasa_rocket_dpmm_new_clusters.py
+++ b/paper_examples/nasa_rocket_dpmm_new_clusters.py
@@ -1,65 +1,55 @@
 import os
 import pandas as pd
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.segmentators.nasa_segmentator import NasaDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
-def main():
-    return
-    run_id = "nasa_rocket_dpmm_new_cluster"
-    nasa_segmentator = NasaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-    )
-    benchmark = NASABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-    channels = NASA.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        base_classifier = DPMMWrapperDetector(
-            mode="new_cluster",      # oppure "new_cluster"
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-        )
-        benchmark.run_classifier(
-            channel_id,
-            classifier=RocketClassifier(
-                base_model=base_classifier,
-                num_kernels=50
-                ),
-            callbacks=callbacks,
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+from utils import compute_and_print_metrics
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+
+def main():
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+
+    for model_type in model_types:
+        run_id = f"nasa_rocket_dpmm_new_cluster_{model_type.lower()}"
+        nasa_segmentator = NasaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
+        )
+        benchmark = NASABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
+        channels = NASA.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            base_classifier = DPMMWrapperDetector(
+                mode="new_cluster",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.8,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+            benchmark.run_classifier(
+                channel_id,
+                classifier=RocketClassifier(
+                    base_model=base_classifier,
+                    num_kernels=50,
+                ),
+                callbacks=callbacks,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        compute_and_print_metrics(results_df, "nasa")
 
 
 if __name__ == "__main__":

--- a/paper_examples/ops_sat_dpmm_experiment.py
+++ b/paper_examples/ops_sat_dpmm_experiment.py
@@ -1,67 +1,58 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+from utils import compute_and_print_metrics
+
 
 def main():
-    return
-    run_id = "ops_sat_dpmm"
-    nasa_segmentator = OPSSATDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations= [
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks",
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var", "kurtosis", "skew"
-        ]
-    )
-    benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    channels = OPSSAT.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        classifier = DPMMWrapperDetector(
-            mode="likelihood",      
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  
+    for model_type in model_types:
+        run_id = f"ops_sat_dpmm_likelihood_{model_type.lower()}"
+        nasa_segmentator = OPSSATDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean", "var", "std", "n_peaks",
+                "smooth10_n_peaks", "smooth20_n_peaks",
+                "diff_peaks", "diff2_peaks", "diff_var", "diff2_var", "kurtosis", "skew",
+            ],
         )
-        benchmark.run_classifier(
-            channel_id,
-            classifier=classifier,
-            callbacks=callbacks,
-            supervised= False
+        benchmark = OPSSATBenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
         )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+        callbacks = [SystemMonitorCallback()]
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        channels = OPSSAT.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            classifier = DPMMWrapperDetector(
+                mode="likelihood",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.8,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+            benchmark.run_classifier(
+                channel_id,
+                classifier=classifier,
+                callbacks=callbacks,
+                supervised=False,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        compute_and_print_metrics(results_df, "ops")
 
 
 if __name__ == "__main__":

--- a/paper_examples/ops_sat_dpmm_new_cluster_experiment.py
+++ b/paper_examples/ops_sat_dpmm_new_cluster_experiment.py
@@ -1,63 +1,54 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+from utils import compute_and_print_metrics
+
 
 def main():
-    return
-    run_id = "ops_sat_dpmm_new_cluster"
-    nasa_segmentator = OPSSATDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=["mean", "std", "var", "stft", "slope", "diff_var"],
-    )
-    benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    channels = OPSSAT.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        classifier = DPMMWrapperDetector(
-            mode="new_cluster",      
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  
+    for model_type in model_types:
+        run_id = f"ops_sat_dpmm_new_cluster_{model_type.lower()}"
+        nasa_segmentator = OPSSATDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=["mean", "std", "var", "stft", "slope", "diff_var"],
         )
-        benchmark.run_classifier(
-            channel_id,
-            classifier=classifier,
-            callbacks=callbacks,
-            supervised= False
+        benchmark = OPSSATBenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
         )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+        callbacks = [SystemMonitorCallback()]
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        channels = OPSSAT.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            classifier = DPMMWrapperDetector(
+                mode="new_cluster",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.8,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+            benchmark.run_classifier(
+                channel_id,
+                classifier=classifier,
+                callbacks=callbacks,
+                supervised=False,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        compute_and_print_metrics(results_df, "ops")
 
 
 if __name__ == "__main__":

--- a/paper_examples/ops_sat_rocket_dpmm_experiment.py
+++ b/paper_examples/ops_sat_rocket_dpmm_experiment.py
@@ -1,69 +1,58 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
-from pyod.models.ecod import ECOD
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+from utils import compute_and_print_metrics
+
 
 def main():
-    run_id = "ops_sat_rocket_dpmm"
-    nasa_segmentator = OPSSATDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-    )
-    benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    channels = OPSSAT.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        base_classifier = DPMMWrapperDetector(
-            mode="likelihood",      
-            model_type="Full",
-            K=10,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  
+    for model_type in model_types:
+        run_id = f"ops_sat_rocket_dpmm_{model_type.lower()}"
+        nasa_segmentator = OPSSATDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
         )
+        benchmark = OPSSATBenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-        benchmark.run_classifier(
-            channel_id,
-            classifier=RocketClassifier(
-                base_model=base_classifier,
-                num_kernels=100
+        channels = OPSSAT.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            base_classifier = DPMMWrapperDetector(
+                mode="likelihood",
+                model_type=model_type,
+                K=10,
+                num_iterations=50,
+                lr=0.8,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=RocketClassifier(
+                    base_model=base_classifier,
+                    num_kernels=1000,
                 ),
-            callbacks=callbacks,
-            supervised=False
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+                callbacks=callbacks,
+                supervised=False,
+            )
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        compute_and_print_metrics(results_df, "ops")
 
 
 if __name__ == "__main__":

--- a/paper_examples/ops_sat_rocket_dpmm_new_cluster_experiment.py
+++ b/paper_examples/ops_sat_rocket_dpmm_new_cluster_experiment.py
@@ -1,69 +1,58 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
-from pyod.models.ecod import ECOD
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+from utils import compute_and_print_metrics
+
 
 def main():
-    run_id = "ops_sat_rocket_dpmm_new_cluster"
-    nasa_segmentator = OPSSATDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-    )
-    benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
 
-    channels = OPSSAT.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        base_classifier = DPMMWrapperDetector(
-            mode="new_cluster",      
-            model_type="Full",
-            K=10,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  
+    for model_type in model_types:
+        run_id = f"ops_sat_rocket_dpmm_new_cluster_{model_type.lower()}"
+        nasa_segmentator = OPSSATDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
         )
+        benchmark = OPSSATBenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=nasa_segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-        benchmark.run_classifier(
-            channel_id,
-            classifier=RocketClassifier(
-                base_model=base_classifier,
-                num_kernels=100
+        channels = OPSSAT.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            base_classifier = DPMMWrapperDetector(
+                mode="new_cluster",
+                model_type=model_type,
+                K=10,
+                num_iterations=50,
+                lr=0.8,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=RocketClassifier(
+                    base_model=base_classifier,
+                    num_kernels=1000,
                 ),
-            callbacks=callbacks,
-            supervised=False
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+                callbacks=callbacks,
+                supervised=False,
+            )
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        compute_and_print_metrics(results_df, "ops")
 
 
 if __name__ == "__main__":

--- a/paper_examples/ops_sat_rocket_xgboost_experiment.py
+++ b/paper_examples/ops_sat_rocket_xgboost_experiment.py
@@ -1,15 +1,14 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
-from pyod.models.ecod import ECOD
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.linear_model import RidgeClassifier
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from xgboost import XGBClassifier
+from utils import compute_and_print_metrics
+
 
 def main():
     run_id = "ops_sat_rocket_xgboost"
@@ -19,44 +18,30 @@ def main():
         extract_features=False,
     )
     benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
+        run_id=run_id,
+        exp_dir="experiments",
         data_root="datasets",
-        segmentator = nasa_segmentator,
+        segmentator=nasa_segmentator,
     )
     callbacks = [SystemMonitorCallback()]
 
     channels = OPSSAT.channel_ids
     for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
+        print(f"{i+1}/{len(channels)}: {channel_id}")
+
         base_classifier = XGBClassifier()
         benchmark.run_classifier(
             channel_id,
             classifier=RocketClassifier(
                 base_model=base_classifier,
-                num_kernels=10000
-                ),
+                num_kernels=1000,
+            ),
             callbacks=callbacks,
-            supervised=True
+            supervised=True,
         )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+    compute_and_print_metrics(results_df, "ops")
 
 
 if __name__ == "__main__":

--- a/paper_examples/utils.py
+++ b/paper_examples/utils.py
@@ -1,0 +1,92 @@
+import os
+import numpy as np
+import pandas as pd
+from spaceai.data.ops_sat import OPSSAT
+from spaceai.data.nasa import NASA
+from spaceai.data.esa import ESA, ESAMissions
+
+def compute_and_print_metrics(results_df: pd.DataFrame, dataset: str) -> None:
+    """Compute and print aggregated metrics.
+
+    Parameters
+    ----------
+    results_df: pd.DataFrame
+        DataFrame produced by a benchmark run containing at least the
+        columns ``true_positives``, ``false_positives``, ``false_negatives``
+        and ``tnr``.
+    dataset: str
+        One of ``"ops"``, ``"nasa"`` or ``"esa"``.
+    """
+    tp = fp = fn = tn = 0
+    total_negatives = 0
+    for _, row in results_df.iterrows():
+        if dataset == "ops":
+            test_channel = OPSSAT(
+                root="datasets",
+                channel_id=row["channel_id"],
+                mode="anomaly",
+                overlapping=False,
+                seq_length=1,
+                train=False,
+                drop_last=False,
+                n_predictions=1,
+            )
+        elif dataset == "nasa":
+            test_channel = NASA(
+                root="datasets",
+                channel_id=row["channel_id"],
+                mode="anomaly",
+                overlapping=False,
+                seq_length=1,
+                train=False,
+                drop_last=False,
+                n_predictions=1,
+            )
+        else:  # ESA
+            test_channel = ESA(
+                root="datasets",
+                channel_id=row["channel_id"],
+                mode="anomaly",
+                overlapping=False,
+                seq_length=1,
+                train=False,
+                drop_last=False,
+                n_predictions=1,
+                mission=ESAMissions.MISSION_1.value,
+            )
+
+        length = len(test_channel.data) // 50
+        labels = np.zeros(length * 50, dtype=int)
+        for start, end in test_channel.anomalies:
+            start = max(0, start)
+            end = min(len(labels) - 1, end)
+            labels[start : end + 1] = 1
+
+        negatives = sum(1 for r in labels.reshape(-1, 50) if np.sum(r) == 0)
+        tn += row["tnr"] * negatives
+        tp += row["true_positives"]
+        fp += row["false_positives"]
+        fn += row["false_negatives"]
+        total_negatives += negatives
+
+    tnr = tn / total_negatives if total_negatives > 0 else 0.0
+    precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+    precision_corrected = precision * tnr
+    recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+    f1 = (
+        2 * (precision_corrected * recall) / (precision_corrected + recall)
+        if precision_corrected + recall > 0
+        else 0.0
+    )
+    f0_5 = (
+        (1 + 0.5 ** 2)
+        * (precision_corrected * recall)
+        / ((0.5 ** 2) * precision_corrected + recall)
+        if precision_corrected + recall > 0
+        else 0.0
+    )
+
+    print("Precision:", precision_corrected)
+    print("Recall:", recall)
+    print("F1:", f1)
+    print("F0.5:", f0_5)

--- a/spaceai/external/dpmm_wrapper/dpmm_core.py
+++ b/spaceai/external/dpmm_wrapper/dpmm_core.py
@@ -16,7 +16,7 @@ def _init_model(model_type, K, D, alphaDP=10):
     else:
         raise ValueError("Invalid model_type")
 
-def get_trained_dpmm_model(X_train, model_type="Full", K=100, num_iterations=100, lr=0.8):
+def get_trained_dpmm_model(X_train, model_type="Full", K=100, num_iterations=50, lr=0.8):
     D = X_train.shape[1]
     dpmm_model = _init_model(model_type, K, D)
 

--- a/spaceai/external/dpmm_wrapper/run_dpmm.py
+++ b/spaceai/external/dpmm_wrapper/run_dpmm.py
@@ -22,7 +22,9 @@ if __name__ == "__main__":
     parser.add_argument("--train", help="CSV di training")
     parser.add_argument("--model_type", default="Full")
     parser.add_argument("--K", type=int, default=100)
-    parser.add_argument("--iterations", type=int, default=100)
+    # Default number of optimisation iterations updated to 50 to keep
+    # consistency with the detector and the experimental setup.
+    parser.add_argument("--iterations", type=int, default=50)
     parser.add_argument("--lr", type=float, default=0.8)
 
     # predict

--- a/spaceai/models/anomaly_classifier/dpmm_detector.py
+++ b/spaceai/models/anomaly_classifier/dpmm_detector.py
@@ -8,7 +8,18 @@ import sys
 from .anomaly_classifier import AnomalyClassifier
 
 class DPMMWrapperDetector(AnomalyClassifier):
-    def __init__(self, mode="likelihood", model_type="Full", K=100, num_iterations=100, lr=0.8, python_executable=None):
+    """Wrapper around the external DPMM implementation.
+
+    The default number of iterations has been aligned with the external
+    implementation and the experiments configuration.  Previously the
+    wrapper used ``num_iterations=100`` while the scripts relied on ``50``.
+    This mismatch caused the detector to run longer than expected when the
+    parameter was not explicitly specified.  The default is now ``50`` so
+    that experiments can omit the argument and obtain the intended behaviour
+    from the latest pull request.
+    """
+
+    def __init__(self, mode="likelihood", model_type="Full", K=100, num_iterations=50, lr=0.8, python_executable=None):
         super().__init__()
         self.mode = mode
         self.model_type = model_type


### PR DESCRIPTION
## Summary
- align DPMM defaults with latest settings (50 iterations)
- add utility to compute precision, recall, F1 and F0.5
- run DPMM and random-kernel XGBoost experiments across model types with updated kernel counts

## Testing
- `pytest --override-ini=addopts=""`
- `pip install pytest-cov` *(fails: Could not find a version that satisfies the requirement pytest-cov)*

------
https://chatgpt.com/codex/tasks/task_e_6894b9eb3f008328a7b2a7f4b9a463cf