### PR TITLE
Expand DPMM experiments with model-type sweeps and tuned kernels

### DIFF
--- a/paper_examples/esa_dpmm_likelihood_experiment.py
+++ b/paper_examples/esa_dpmm_likelihood_experiment.py
@@ -1,76 +1,91 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
+from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+
 
 def main():
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"esa_dpmm_likelihood_{model_type.lower()}"
+        segmentator = EsaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean",
+                "var",
+                "std",
+                "n_peaks",
+                "smooth10_n_peaks",
+                "smooth20_n_peaks",
+                "diff_peaks",
+                "diff2_peaks",
+                "diff_var",
+                "diff2_var",
+            ],
+            segments_id="channel_segments",
+        )
+        benchmark = ESABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-    run_id = "esa_dpmm_likelihood_experiment"
-    nasa_segmentator = EsaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-        segments_id="channel_segments"
-    )
-    benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-
-    for mission_wrapper in ESAMissions:
-        mission = mission_wrapper.value
-        if mission.index != 1:
-            continue
-        for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+        for mission_wrapper in ESAMissions:
+            mission = mission_wrapper.value
+            if mission.index != 1:
                 continue
-            detector = DPMMWrapperDetector(
-                mode="likelihood",      # oppure "new_cluster"
-                model_type="Full",
-                K=100,
-                num_iterations=50,
-                lr=0.8,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-            )
+            for channel_id in mission.target_channels:
+                if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
+                    continue
+                detector = DPMMWrapperDetector(
+                    mode="likelihood",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.1,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )
 
-            benchmark.run_classifier(
-                mission=mission,
-                channel_id=channel_id,
-                classifier=detector,
-                callbacks=callbacks,
-                supervised=False
-            )
-            
+                benchmark.run_classifier(
+                    mission=mission,
+                    channel_id=channel_id,
+                    classifier=detector,
+                    callbacks=callbacks,
+                    supervised=False,
+                )
+
         results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
 
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/esa_dpmm_new_cluster_experiment.py
+++ b/paper_examples/esa_dpmm_new_cluster_experiment.py
@@ -1,75 +1,91 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
+from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+
 
 def main():
-    run_id = "esa_dpmm_new_clusters_experiment"
-    nasa_segmentator = EsaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-        segments_id="channel_segments"
-    )
-    benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"esa_dpmm_new_cluster_{model_type.lower()}"
+        segmentator = EsaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean",
+                "var",
+                "std",
+                "n_peaks",
+                "smooth10_n_peaks",
+                "smooth20_n_peaks",
+                "diff_peaks",
+                "diff2_peaks",
+                "diff_var",
+                "diff2_var",
+            ],
+            segments_id="channel_segments",
+        )
+        benchmark = ESABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-    for mission_wrapper in ESAMissions:
-        mission = mission_wrapper.value
-        if mission.index != 1:
-            continue
-        for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+        for mission_wrapper in ESAMissions:
+            mission = mission_wrapper.value
+            if mission.index != 1:
                 continue
-            detector = DPMMWrapperDetector(
-                mode="new_cluster",      # oppure "new_cluster"
-                model_type="Full",
-                K=100,
-                num_iterations=50,
-                lr=0.8,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-            )
+            for channel_id in mission.target_channels:
+                if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
+                    continue
+                detector = DPMMWrapperDetector(
+                    mode="new_cluster",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.1,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )
 
-            benchmark.run_classifier(
-                mission=mission,
-                channel_id=channel_id,
-                classifier=detector,
-                callbacks=callbacks,
-                supervised=False
-            )
-            
+                benchmark.run_classifier(
+                    mission=mission,
+                    channel_id=channel_id,
+                    classifier=detector,
+                    callbacks=callbacks,
+                    supervised=False,
+                )
+
         results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
 
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/esa_rocket_dpmm_likelihood_experiment.py
+++ b/paper_examples/esa_rocket_dpmm_likelihood_experiment.py
@@ -1,85 +1,95 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
-
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+
+
 def main():
-    
-    run_id = "esa_rocket_dpmm_likelihood_experiment"
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"esa_rocket_dpmm_likelihood_{model_type.lower()}"
+        segmentator = EsaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
+            transformations=[
+                "mean",
+                "var",
+                "std",
+                "n_peaks",
+                "smooth10_n_peaks",
+                "smooth20_n_peaks",
+                "diff_peaks",
+                "diff2_peaks",
+                "diff_var",
+                "diff2_var",
+            ],
+            segments_id="channel_segments",
+            save_csv=False,
+        )
+        benchmark = ESABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-    nasa_segmentator = EsaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-        segments_id="channel_segments",
-        save_csv=False
-    )
-
-    benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-    for mission_wrapper in ESAMissions:
-        mission = mission_wrapper.value
-        if mission.index != 1:
-            continue
-        for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+        for mission_wrapper in ESAMissions:
+            mission = mission_wrapper.value
+            if mission.index != 1:
                 continue
-            base_classifier = DPMMWrapperDetector(
-                mode="likelihood",      # oppure "new_cluster"
-                model_type="Full",
-                K=100,
-                num_iterations=50,
-                lr=0.8,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-            )
-            benchmark.run_classifier(
-                mission=mission,
-                channel_id=channel_id,
-                classifier=RocketClassifier(
-                    base_model=base_classifier,
-                    num_kernels=10
+            for channel_id in mission.target_channels:
+                if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
+                    continue
+                base_classifier = DPMMWrapperDetector(
+                    mode="likelihood",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.1,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )
+                benchmark.run_classifier(
+                    mission=mission,
+                    channel_id=channel_id,
+                    classifier=RocketClassifier(
+                        base_model=base_classifier,
+                        num_kernels=10,
                     ),
-                callbacks=callbacks,
-                supervised=False
-            )
+                    callbacks=callbacks,
+                    supervised=False,
+                )
 
-            
         results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
 
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/esa_rocket_dpmm_new_cluster_experiment.py
+++ b/paper_examples/esa_rocket_dpmm_new_cluster_experiment.py
@@ -1,83 +1,95 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.esa_segmentator import EsaDatasetSegmentator
-
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
-def main():
-   
-    run_id = "esa_rocket_dpmm_new_cluster_experiment"
 
-    nasa_segmentator = EsaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-        segments_id="channel_segments",
-        save_csv=False
-    )
-    benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-    for mission_wrapper in ESAMissions:
-        mission = mission_wrapper.value
-        if mission.index != 1:
-            continue
-        for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+
+def main():
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"esa_rocket_dpmm_new_cluster_{model_type.lower()}"
+        segmentator = EsaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
+            transformations=[
+                "mean",
+                "var",
+                "std",
+                "n_peaks",
+                "smooth10_n_peaks",
+                "smooth20_n_peaks",
+                "diff_peaks",
+                "diff2_peaks",
+                "diff_var",
+                "diff2_var",
+            ],
+            segments_id="channel_segments",
+            save_csv=False,
+        )
+        benchmark = ESABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
+
+        for mission_wrapper in ESAMissions:
+            mission = mission_wrapper.value
+            if mission.index != 1:
                 continue
-            base_classifier = DPMMWrapperDetector(
-                mode="new_cluster",      # oppure "new_cluster"
-                model_type="Full",
-                K=100,
-                num_iterations=50,
-                lr=0.8,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-            )
-            benchmark.run_classifier(
-                mission=mission,
-                channel_id=channel_id,
-                classifier=RocketClassifier(
-                    base_model=base_classifier,
-                    num_kernels=10
+            for channel_id in mission.target_channels:
+                if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
+                    continue
+                base_classifier = DPMMWrapperDetector(
+                    mode="new_cluster",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.1,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )
+                benchmark.run_classifier(
+                    mission=mission,
+                    channel_id=channel_id,
+                    classifier=RocketClassifier(
+                        base_model=base_classifier,
+                        num_kernels=10,
                     ),
-                callbacks=callbacks,
-                supervised=False
-            )
+                    callbacks=callbacks,
+                    supervised=False,
+                )
 
         results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
 
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/esa_rocket_xgboost_experiment.py
+++ b/paper_examples/esa_rocket_xgboost_experiment.py
@@ -20,18 +20,25 @@ def main():
         step_duration=50,
         extract_features=False,
         transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
+            "mean",
+            "var",
+            "std",
+            "n_peaks",
+            "smooth10_n_peaks",
+            "smooth20_n_peaks",
+            "diff_peaks",
+            "diff2_peaks",
+            "diff_var",
+            "diff2_var",
         ],
         segments_id="channel_segments",
-        save_csv=False
+        save_csv=False,
     )
     benchmark = ESABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
+        run_id=run_id,
+        exp_dir="experiments",
         data_root="datasets",
-        segmentator = nasa_segmentator,
+        segmentator=nasa_segmentator,
     )
     callbacks = [SystemMonitorCallback()]
     for mission_wrapper in ESAMissions:
@@ -39,7 +46,7 @@ def main():
         if mission.index != 1:
             continue
         for channel_id in mission.target_channels:
-            if int(channel_id.split("_")[1])<41 or int(channel_id.split("_")[1])>46:
+            if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
                 continue
 
             benchmark.run_classifier(
@@ -47,28 +54,36 @@ def main():
                 channel_id=channel_id,
                 classifier=RocketClassifier(
                     base_model=XGBClassifier(),
-                    num_kernels=500
-                    ),
+                    num_kernels=10,
+                ),
                 callbacks=callbacks,
-                supervised=True
+                supervised=True,
             )
-            
-        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-        tp = results_df['true_positives'].sum()
-        fp = results_df['false_positives'].sum()
-        fn = results_df['false_negatives'].sum()
 
-        total_precision = tp / (tp + fp)
-        total_recall = tp / (tp + fn)
-        total_f1 = 2 * (total_precision * total_recall) / \
-            (total_precision + total_recall)
-        
-        print("True Positives: ", tp)
-        print("False Positives: ", fp)
-        print("False Negatives: ", fn)
-        print("Total Precision: ", total_precision)
-        print("Total Recall: ", total_recall)
-        print("Total F1: ", total_f1)
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2)
+            * precision
+            * recall
+            / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":

--- a/paper_examples/nasa_dpmm_likelihood_experiment.py
+++ b/paper_examples/nasa_dpmm_likelihood_experiment.py
@@ -1,71 +1,85 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.nasa_segmentator import NasaDatasetSegmentator
+from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+
 
 def main():
-    
-    run_id = "nasa_dpmm_likelihood_experiment"
-    nasa_segmentator = NasaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-    )
-    benchmark = NASABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"nasa_dpmm_likelihood_{model_type.lower()}"
+        segmentator = NasaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean",
+                "var",
+                "std",
+                "n_peaks",
+                "smooth10_n_peaks",
+                "smooth20_n_peaks",
+                "diff_peaks",
+                "diff2_peaks",
+                "diff_var",
+                "diff2_var",
+            ],
+        )
+        benchmark = NASABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-    channels = NASA.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        detector = DPMMWrapperDetector(
-            mode="likelihood",      # oppure "new_cluster"
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
+        channels = NASA.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            detector = DPMMWrapperDetector(
+                mode="likelihood",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.1,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=detector,
+                callbacks=callbacks,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
         )
 
-        benchmark.run_classifier(
-            channel_id,
-            classifier=detector,
-            callbacks=callbacks,
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
-
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/nasa_dpmm_new_cluster_experiment.py
+++ b/paper_examples/nasa_dpmm_new_cluster_experiment.py
@@ -1,71 +1,85 @@
 import os
-
 import pandas as pd
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
-
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
-from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 from spaceai.segmentators.nasa_segmentator import NasaDatasetSegmentator
+from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
+
 
 def main():
-    
-    run_id = "nasa_dpmm_new_cluster_experiment"
-    nasa_segmentator = NasaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=[
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks", 
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var",
-        ],
-    )
-    benchmark = NASABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"nasa_dpmm_new_cluster_{model_type.lower()}"
+        segmentator = NasaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean",
+                "var",
+                "std",
+                "n_peaks",
+                "smooth10_n_peaks",
+                "smooth20_n_peaks",
+                "diff_peaks",
+                "diff2_peaks",
+                "diff_var",
+                "diff2_var",
+            ],
+        )
+        benchmark = NASABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-    channels = NASA.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        detector = DPMMWrapperDetector(
-            mode="new_cluster",      # oppure "new_cluster"
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
+        channels = NASA.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            detector = DPMMWrapperDetector(
+                mode="new_cluster",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.1,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=detector,
+                callbacks=callbacks,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
         )
 
-        benchmark.run_classifier(
-            channel_id,
-            classifier=detector,
-            callbacks=callbacks,
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
-
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/nasa_rocket_dpmm_experiment.py
+++ b/paper_examples/nasa_rocket_dpmm_experiment.py
@@ -1,66 +1,77 @@
 import os
 import pandas as pd
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.segmentators.nasa_segmentator import NasaDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
-def main():
-    return
-    run_id = "nasa_rocket_dpmm"
-    nasa_segmentator = NasaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-    )
-    benchmark = NASABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-    channels = NASA.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        base_classifier = DPMMWrapperDetector(
-            mode="likelihood",      # oppure "new_cluster"
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-        )
-        benchmark.run_classifier(
-            channel_id,
-            classifier=RocketClassifier(
-                base_model=base_classifier,
-                num_kernels=50
-                ),
-            callbacks=callbacks,
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+
+def main():
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"nasa_rocket_dpmm_{model_type.lower()}"
+        segmentator = NasaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
+        )
+        benchmark = NASABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
+
+        channels = NASA.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            base_classifier = DPMMWrapperDetector(
+                mode="likelihood",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.1,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=RocketClassifier(
+                    base_model=base_classifier,
+                    num_kernels=50,
+                ),
+                callbacks=callbacks,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/nasa_rocket_dpmm_new_clusters.py
+++ b/paper_examples/nasa_rocket_dpmm_new_clusters.py
@@ -1,66 +1,77 @@
 import os
 import pandas as pd
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.segmentators.nasa_segmentator import NasaDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.svm import OneClassSVM
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
-def main():
-    return
-    run_id = "nasa_rocket_dpmm_new_cluster"
-    nasa_segmentator = NasaDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-    )
-    benchmark = NASABenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-    channels = NASA.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        base_classifier = DPMMWrapperDetector(
-            mode="new_cluster",      # oppure "new_cluster"
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  # Inserisci il percorso corretto del tuo ambiente Python
-        )
-        benchmark.run_classifier(
-            channel_id,
-            classifier=RocketClassifier(
-                base_model=base_classifier,
-                num_kernels=50
-                ),
-            callbacks=callbacks,
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+
+def main():
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"nasa_rocket_dpmm_new_cluster_{model_type.lower()}"
+        segmentator = NasaDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
+        )
+        benchmark = NASABenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
+
+        channels = NASA.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            base_classifier = DPMMWrapperDetector(
+                mode="new_cluster",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.1,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=RocketClassifier(
+                    base_model=base_classifier,
+                    num_kernels=50,
+                ),
+                callbacks=callbacks,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/ops_sat_dpmm_experiment.py
+++ b/paper_examples/ops_sat_dpmm_experiment.py
@@ -1,68 +1,87 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 
+
 def main():
-    return
-    run_id = "ops_sat_dpmm"
-    nasa_segmentator = OPSSATDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations= [
-            "mean", "var", "std", "n_peaks",
-            "smooth10_n_peaks", "smooth20_n_peaks",
-            "diff_peaks", "diff2_peaks", "diff_var", "diff2_var", "kurtosis", "skew"
-        ]
-    )
-    benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-
-    channels = OPSSAT.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        classifier = DPMMWrapperDetector(
-            mode="likelihood",      
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"ops_sat_dpmm_{model_type.lower()}"
+        segmentator = OPSSATDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean",
+                "var",
+                "std",
+                "n_peaks",
+                "smooth10_n_peaks",
+                "smooth20_n_peaks",
+                "diff_peaks",
+                "diff2_peaks",
+                "diff_var",
+                "diff2_var",
+                "kurtosis",
+                "skew",
+            ],
         )
-        benchmark.run_classifier(
-            channel_id,
-            classifier=classifier,
-            callbacks=callbacks,
-            supervised= False
+        benchmark = OPSSATBenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
         )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+        callbacks = [SystemMonitorCallback()]
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        channels = OPSSAT.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            classifier = DPMMWrapperDetector(
+                mode="likelihood",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.1,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+            benchmark.run_classifier(
+                channel_id,
+                classifier=classifier,
+                callbacks=callbacks,
+                supervised=False,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/ops_sat_dpmm_new_cluster_experiment.py
+++ b/paper_examples/ops_sat_dpmm_new_cluster_experiment.py
@@ -1,64 +1,81 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 
+
 def main():
-    return
-    run_id = "ops_sat_dpmm_new_cluster"
-    nasa_segmentator = OPSSATDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=True,
-        transformations=["mean", "std", "var", "stft", "slope", "diff_var"],
-    )
-    benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-
-    channels = OPSSAT.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        classifier = DPMMWrapperDetector(
-            mode="new_cluster",      
-            model_type="Full",
-            K=100,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"ops_sat_dpmm_new_cluster_{model_type.lower()}"
+        segmentator = OPSSATDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=True,
+            transformations=[
+                "mean",
+                "std",
+                "var",
+                "stft",
+                "slope",
+                "diff_var",
+            ],
         )
-        benchmark.run_classifier(
-            channel_id,
-            classifier=classifier,
-            callbacks=callbacks,
-            supervised= False
+        benchmark = OPSSATBenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
         )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+        callbacks = [SystemMonitorCallback()]
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        channels = OPSSAT.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            classifier = DPMMWrapperDetector(
+                mode="new_cluster",
+                model_type=model_type,
+                K=100,
+                num_iterations=50,
+                lr=0.1,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+            benchmark.run_classifier(
+                channel_id,
+                classifier=classifier,
+                callbacks=callbacks,
+                supervised=False,
+            )
+
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/ops_sat_rocket_dpmm_experiment.py
+++ b/paper_examples/ops_sat_rocket_dpmm_experiment.py
@@ -1,70 +1,78 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
-from pyod.models.ecod import ECOD
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 
+
 def main():
-    run_id = "ops_sat_rocket_dpmm"
-    nasa_segmentator = OPSSATDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-    )
-    benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-
-    channels = OPSSAT.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        base_classifier = DPMMWrapperDetector(
-            mode="likelihood",      
-            model_type="Full",
-            K=10,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"ops_sat_rocket_dpmm_{model_type.lower()}"
+        segmentator = OPSSATDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
         )
+        benchmark = OPSSATBenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-        benchmark.run_classifier(
-            channel_id,
-            classifier=RocketClassifier(
-                base_model=base_classifier,
-                num_kernels=100
+        channels = OPSSAT.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            base_classifier = DPMMWrapperDetector(
+                mode="likelihood",
+                model_type=model_type,
+                K=10,
+                num_iterations=50,
+                lr=0.1,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=RocketClassifier(
+                    base_model=base_classifier,
+                    num_kernels=1000,
                 ),
-            callbacks=callbacks,
-            supervised=False
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+                callbacks=callbacks,
+                supervised=False,
+            )
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/ops_sat_rocket_dpmm_new_cluster_experiment.py
+++ b/paper_examples/ops_sat_rocket_dpmm_new_cluster_experiment.py
@@ -1,70 +1,78 @@
 import os
 import pandas as pd
+
 from spaceai.data.ops_sat import OPSSAT
 from spaceai.benchmark import OPSSATBenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
-from sklearn.svm import OneClassSVM
-from pyod.models.ecod import ECOD
 from spaceai.segmentators.ops_sat_segmentator import OPSSATDatasetSegmentator
 from spaceai.models.anomaly_classifier import RocketClassifier
-from sklearn.linear_model import RidgeClassifier
 from spaceai.models.anomaly_classifier.dpmm_detector import DPMMWrapperDetector
 
+
 def main():
-    run_id = "ops_sat_rocket_dpmm_new_cluster"
-    nasa_segmentator = OPSSATDatasetSegmentator(
-        segment_duration=50,
-        step_duration=50,
-        extract_features=False,
-    )
-    benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
-        data_root="datasets",
-        segmentator = nasa_segmentator,
-    )
-    callbacks = [SystemMonitorCallback()]
-
-    channels = OPSSAT.channel_ids
-    for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
-        base_classifier = DPMMWrapperDetector(
-            mode="new_cluster",      
-            model_type="Full",
-            K=10,
-            num_iterations=50,
-            lr=0.8,
-            python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python"  
+    model_types = ["Full", "Diagonal", "Single", "Unit"]
+    for model_type in model_types:
+        run_id = f"ops_sat_rocket_dpmm_new_cluster_{model_type.lower()}"
+        segmentator = OPSSATDatasetSegmentator(
+            segment_duration=50,
+            step_duration=50,
+            extract_features=False,
         )
+        benchmark = OPSSATBenchmark(
+            run_id=run_id,
+            exp_dir="experiments",
+            data_root="datasets",
+            segmentator=segmentator,
+        )
+        callbacks = [SystemMonitorCallback()]
 
-        benchmark.run_classifier(
-            channel_id,
-            classifier=RocketClassifier(
-                base_model=base_classifier,
-                num_kernels=100
+        channels = OPSSAT.channel_ids
+        for i, channel_id in enumerate(channels):
+            print(f"{i+1}/{len(channels)}: {channel_id}")
+
+            base_classifier = DPMMWrapperDetector(
+                mode="new_cluster",
+                model_type=model_type,
+                K=10,
+                num_iterations=50,
+                lr=0.1,
+                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+            )
+
+            benchmark.run_classifier(
+                channel_id,
+                classifier=RocketClassifier(
+                    base_model=base_classifier,
+                    num_kernels=1000,
                 ),
-            callbacks=callbacks,
-            supervised=False
-        )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
+                callbacks=callbacks,
+                supervised=False,
+            )
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+        results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+        tp = results_df["true_positives"].sum()
+        fp = results_df["false_positives"].sum()
+        fn = results_df["false_negatives"].sum()
+
+        precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+        recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+        f0_5 = (
+            (1 + 0.5**2) * precision * recall / (0.5**2 * precision + recall)
+            if (0.5**2 * precision + recall) > 0
+            else 0.0
+        )
+
+        print(f"Results for {model_type}:")
+        print("True Positives:", tp)
+        print("False Positives:", fp)
+        print("False Negatives:", fn)
+        print("Precision:", precision)
+        print("Recall:", recall)
+        print("F1:", f1)
+        print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":
     main()
+

--- a/paper_examples/ops_sat_rocket_xgboost_experiment.py
+++ b/paper_examples/ops_sat_rocket_xgboost_experiment.py
@@ -19,44 +19,52 @@ def main():
         extract_features=False,
     )
     benchmark = OPSSATBenchmark(
-        run_id=run_id, 
-        exp_dir="experiments", 
+        run_id=run_id,
+        exp_dir="experiments",
         data_root="datasets",
-        segmentator = nasa_segmentator,
+        segmentator=nasa_segmentator,
     )
     callbacks = [SystemMonitorCallback()]
 
     channels = OPSSAT.channel_ids
     for i, channel_id in enumerate(channels):
-        print(f'{i+1}/{len(channels)}: {channel_id}')
-        
+        print(f"{i+1}/{len(channels)}: {channel_id}")
+
         base_classifier = XGBClassifier()
         benchmark.run_classifier(
             channel_id,
             classifier=RocketClassifier(
                 base_model=base_classifier,
-                num_kernels=10000
-                ),
+                num_kernels=1000,
+            ),
             callbacks=callbacks,
-            supervised=True
+            supervised=True,
         )
-        
-    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
-    tp = results_df['true_positives'].sum()
-    fp = results_df['false_positives'].sum()
-    fn = results_df['false_negatives'].sum()
 
-    total_precision = tp / (tp + fp)
-    total_recall = tp / (tp + fn)
-    total_f1 = 2 * (total_precision * total_recall) / \
-        (total_precision + total_recall)
-    
-    print("True Positives: ", tp)
-    print("False Positives: ", fp)
-    print("False Negatives: ", fn)
-    print("Total Precision: ", total_precision)
-    print("Total Recall: ", total_recall)
-    print("Total F1: ", total_f1)
+    results_df = pd.read_csv(os.path.join(benchmark.run_dir, "results.csv"))
+    tp = results_df["true_positives"].sum()
+    fp = results_df["false_positives"].sum()
+    fn = results_df["false_negatives"].sum()
+
+    precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+    recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+    f0_5 = (
+        (1 + 0.5**2)
+        * precision
+        * recall
+        / (0.5**2 * precision + recall)
+        if (0.5**2 * precision + recall) > 0
+        else 0.0
+    )
+
+    print("True Positives:", tp)
+    print("False Positives:", fp)
+    print("False Negatives:", fn)
+    print("Precision:", precision)
+    print("Recall:", recall)
+    print("F1:", f1)
+    print("F0.5:", f0_5)
 
 
 if __name__ == "__main__":

--- a/spaceai/external/dpmm_wrapper/dpmm_core.py
+++ b/spaceai/external/dpmm_wrapper/dpmm_core.py
@@ -4,19 +4,49 @@ import torch.optim as optim
 from torch_dpmm.models import FullGaussianDPMM, DiagonalGaussianDPMM, SingleGaussianDPMM, UnitGaussianDPMM
 from tqdm import tqdm
 
-def _init_model(model_type, K, D, alphaDP=10):
+def _init_model(model_type, K, D, alphaDP=1):
     if model_type == "Full":
-        return FullGaussianDPMM(K, D, alphaDP, mu_prior=0, mu_prior_strength=0.01, var_prior=0.1, var_prior_strength=10)
+        return FullGaussianDPMM(
+            K,
+            D,
+            alphaDP,
+            mu_prior=0,
+            mu_prior_strength=0.1,
+            var_prior=1.0,
+            var_prior_strength=1.0,
+        )
     elif model_type == "Diagonal":
-        return DiagonalGaussianDPMM(K, D, alphaDP, mu_prior=0, mu_prior_strength=0.01, var_prior=0.1, var_prior_strength=10)
+        return DiagonalGaussianDPMM(
+            K,
+            D,
+            alphaDP,
+            mu_prior=0,
+            mu_prior_strength=0.1,
+            var_prior=1.0,
+            var_prior_strength=1.0,
+        )
     elif model_type == "Single":
-        return SingleGaussianDPMM(K, D, alphaDP, mu_prior=0, mu_prior_strength=0.01, var_prior=0.1, var_prior_strength=10)
+        return SingleGaussianDPMM(
+            K,
+            D,
+            alphaDP,
+            mu_prior=0,
+            mu_prior_strength=0.1,
+            var_prior=1.0,
+            var_prior_strength=1.0,
+        )
     elif model_type == "Unit":
-        return UnitGaussianDPMM(K, D, alphaDP, mu_prior=0, mu_prior_strength=0.01)
+        return UnitGaussianDPMM(
+            K,
+            D,
+            alphaDP,
+            mu_prior=0,
+            mu_prior_strength=0.1,
+        )
     else:
         raise ValueError("Invalid model_type")
 
-def get_trained_dpmm_model(X_train, model_type="Full", K=100, num_iterations=100, lr=0.8):
+def get_trained_dpmm_model(X_train, model_type="Full", K=100, num_iterations=100, lr=0.1):
     D = X_train.shape[1]
     dpmm_model = _init_model(model_type, K, D)
 


### PR DESCRIPTION
## Summary
- adjust default DPMM priors and training rate
- extend DPMM and Rocket-XGBoost experiments to cover Full/Diagonal/Single/Unit models
- unify metric reporting with precision, F1 and F0.5

## Testing
- `python -m py_compile spaceai/external/dpmm_wrapper/dpmm_core.py paper_examples/ops_sat_dpmm_experiment.py paper_examples/ops_sat_dpmm_new_cluster_experiment.py paper_examples/ops_sat_rocket_dpmm_experiment.py paper_examples/ops_sat_rocket_dpmm_new_cluster_experiment.py paper_examples/ops_sat_rocket_xgboost_experiment.py paper_examples/nasa_dpmm_likelihood_experiment.py paper_examples/nasa_dpmm_new_cluster_experiment.py paper_examples/nasa_rocket_dpmm_experiment.py paper_examples/nasa_rocket_dpmm_new_clusters.py paper_examples/esa_dpmm_likelihood_experiment.py paper_examples/esa_dpmm_new_cluster_experiment.py paper_examples/esa_rocket_dpmm_likelihood_experiment.py paper_examples/esa_rocket_dpmm_new_cluster_experiment.py paper_examples/esa_rocket_xgboost_experiment.py`

------
https://chatgpt.com/codex/tasks/task_e_6894c281979c83288c56edeaa2d505fe