### PR TITLE
Align ESA/NASA DPMM experiments with new preprocessing

### DIFF
--- a/paper_examples/esa_rocket_dpmm_likelihood_experiment.py
+++ b/paper_examples/esa_rocket_dpmm_likelihood_experiment.py
@@ -1,6 +1,9 @@
 import os
 import pandas as pd
 
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import RobustScaler
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
@@ -47,14 +50,17 @@ def main():
             for channel_id in mission.target_channels:
                 if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
                     continue
-                base_classifier = DPMMWrapperDetector(
-                    mode="likelihood",
-                    model_type=model_type,
-                    K=100,
-                    num_iterations=50,
-                    lr=0.1,
-                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
-                )
+                base_classifier = Pipeline([
+                    ("scaler", RobustScaler(with_centering=False)),
+                    ("dpmm", DPMMWrapperDetector(
+                        mode="likelihood_threshold",
+                        model_type=model_type,
+                        K=100,
+                        num_iterations=50,
+                        lr=0.1,
+                        python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                    )),
+                ])
                 benchmark.run_classifier(
                     mission=mission,
                     channel_id=channel_id,

--- a/paper_examples/esa_rocket_dpmm_new_cluster_experiment.py
+++ b/paper_examples/esa_rocket_dpmm_new_cluster_experiment.py
@@ -1,6 +1,9 @@
 import os
 import pandas as pd
 
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import RobustScaler
+
 from spaceai.data import ESA, ESAMissions
 from spaceai.benchmark import ESABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
@@ -47,14 +50,17 @@ def main():
             for channel_id in mission.target_channels:
                 if int(channel_id.split("_")[1]) < 41 or int(channel_id.split("_")[1]) > 46:
                     continue
-                base_classifier = DPMMWrapperDetector(
-                    mode="new_cluster",
-                    model_type=model_type,
-                    K=100,
-                    num_iterations=50,
-                    lr=0.1,
-                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
-                )
+                base_classifier = Pipeline([
+                    ("scaler", RobustScaler(with_centering=False)),
+                    ("dpmm", DPMMWrapperDetector(
+                        mode="cluster_labels",
+                        model_type=model_type,
+                        K=100,
+                        num_iterations=50,
+                        lr=0.1,
+                        python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                    )),
+                ])
                 benchmark.run_classifier(
                     mission=mission,
                     channel_id=channel_id,

--- a/paper_examples/nasa_dpmm_new_cluster_experiment.py
+++ b/paper_examples/nasa_dpmm_new_cluster_experiment.py
@@ -1,6 +1,9 @@
 import os
 import pandas as pd
 
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import RobustScaler
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
@@ -41,18 +44,21 @@ def main():
         for i, channel_id in enumerate(channels):
             print(f"{i+1}/{len(channels)}: {channel_id}")
 
-            detector = DPMMWrapperDetector(
-                mode="new_cluster",
-                model_type=model_type,
-                K=100,
-                num_iterations=50,
-                lr=0.1,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
-            )
+            pipeline = Pipeline([
+                ("scaler", RobustScaler(with_centering=False)),
+                ("dpmm", DPMMWrapperDetector(
+                    mode="cluster_labels",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.1,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )),
+            ])
 
             benchmark.run_classifier(
                 channel_id,
-                classifier=detector,
+                classifier=pipeline,
                 callbacks=callbacks,
             )
 

--- a/paper_examples/nasa_rocket_dpmm_experiment.py
+++ b/paper_examples/nasa_rocket_dpmm_experiment.py
@@ -1,6 +1,9 @@
 import os
 import pandas as pd
 
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import RobustScaler
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
@@ -30,14 +33,17 @@ def main():
         for i, channel_id in enumerate(channels):
             print(f"{i+1}/{len(channels)}: {channel_id}")
 
-            base_classifier = DPMMWrapperDetector(
-                mode="likelihood",
-                model_type=model_type,
-                K=100,
-                num_iterations=50,
-                lr=0.1,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
-            )
+            base_classifier = Pipeline([
+                ("scaler", RobustScaler(with_centering=False)),
+                ("dpmm", DPMMWrapperDetector(
+                    mode="likelihood_threshold",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.1,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )),
+            ])
 
             benchmark.run_classifier(
                 channel_id,

--- a/paper_examples/nasa_rocket_dpmm_new_clusters.py
+++ b/paper_examples/nasa_rocket_dpmm_new_clusters.py
@@ -1,6 +1,9 @@
 import os
 import pandas as pd
 
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import RobustScaler
+
 from spaceai.data import NASA
 from spaceai.benchmark import NASABenchmark
 from spaceai.benchmark.callbacks import SystemMonitorCallback
@@ -30,14 +33,17 @@ def main():
         for i, channel_id in enumerate(channels):
             print(f"{i+1}/{len(channels)}: {channel_id}")
 
-            base_classifier = DPMMWrapperDetector(
-                mode="new_cluster",
-                model_type=model_type,
-                K=100,
-                num_iterations=50,
-                lr=0.1,
-                python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
-            )
+            base_classifier = Pipeline([
+                ("scaler", RobustScaler(with_centering=False)),
+                ("dpmm", DPMMWrapperDetector(
+                    mode="cluster_labels",
+                    model_type=model_type,
+                    K=100,
+                    num_iterations=50,
+                    lr=0.1,
+                    python_executable="/opt/homebrew/Caskroom/miniconda/base/envs/dpmm_env/bin/python",
+                )),
+            ])
 
             benchmark.run_classifier(
                 channel_id,


### PR DESCRIPTION
## Summary
- switch ESA and NASA DPMM experiments to the new `likelihood_threshold` and `cluster_labels` modes
- wrap every ESA/NASA DPMM detector (including ROCKET variants) in a `Pipeline` with a `RobustScaler`
- keep execution logic the same while ensuring scaling happens before inference

## Testing
- python -m compileall   paper_examples/esa_dpmm_likelihood_experiment.py   paper_examples/esa_dpmm_new_cluster_experiment.py   paper_examples/esa_rocket_dpmm_likelihood_experiment.py   paper_examples/esa_rocket_dpmm_new_cluster_experiment.py   paper_examples/nasa_dpmm_new_cluster_experiment.py   paper_examples/nasa_rocket_dpmm_experiment.py   paper_examples/nasa_rocket_dpmm_new_clusters.py


------
https://chatgpt.com/codex/tasks/task_e_68d30050d5b08328ad0535106c4077db