### PR TITLE
feat: add ecoGrow prompt learning pipeline

### DIFF
--- a/examples/ecoGrow_prompt_tuning.py
+++ b/examples/ecoGrow_prompt_tuning.py
@@ -1,0 +1,93 @@
+"""Command line entry-point for ecoGrow prompt tuning experiments."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import open_clip
+import torch
+
+from spaceai.data import PlantDataModule, PlantDataModuleConfig
+from spaceai.models.prompt_learning import PromptTuningTrainer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("data_root", type=Path, help="Root directory containing the plant datasets")
+    parser.add_argument("prompts", type=Path, help="JSON file with plant prompts")
+    parser.add_argument("--plants", nargs="*", default=None, help="Subset of plants to train on")
+    parser.add_argument("--model", default="ViT-B-16", help="OpenCLIP model architecture")
+    parser.add_argument("--pretrained", default="laion2b_s34b_b88k", help="OpenCLIP pre-trained weights")
+    parser.add_argument("--device", default=None, help="Training device (defaults to auto-detect)")
+    parser.add_argument("--epochs", type=int, default=20, help="Number of fine-tuning epochs")
+    parser.add_argument("--batch-size", type=int, default=16, dest="batch_size", help="Batch size")
+    parser.add_argument("--num-workers", type=int, default=4, dest="num_workers", help="DataLoader workers")
+    parser.add_argument("--n-ctx", type=int, default=16, dest="n_ctx", help="Number of context tokens")
+    parser.add_argument("--ctx-init", default=None, dest="ctx_init", help="Initial context string")
+    parser.add_argument(
+        "--template",
+        default="a close-up photo of {description}",
+        help="Prompt template used to build textual descriptions",
+    )
+    parser.add_argument("--lr", type=float, default=5e-3, help="Learning rate for the prompt learner")
+    parser.add_argument("--weight-decay", type=float, default=0.0, dest="weight_decay", help="Optimizer weight decay")
+    parser.add_argument(
+        "--split-ratio",
+        nargs=3,
+        type=float,
+        default=(0.7, 0.15, 0.15),
+        metavar=("TRAIN", "VAL", "TEST"),
+        help="Split ratios when a plant dataset is not already split",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device) if args.device else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    model, preprocess_train, preprocess_val = open_clip.create_model_and_transforms(
+        args.model,
+        pretrained=args.pretrained,
+        device=device,
+    )
+
+    config = PlantDataModuleConfig(
+        data_root=args.data_root,
+        prompts_path=args.prompts,
+        plant_names=args.plants,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        split_ratio=tuple(args.split_ratio),
+    )
+    datamodule = PlantDataModule(config)
+
+    trainer = PromptTuningTrainer(
+        clip_model=model.to(device),
+        preprocess_train=preprocess_train,
+        preprocess_val=preprocess_val,
+        device=device,
+        epochs=args.epochs,
+        lr=args.lr,
+        weight_decay=args.weight_decay,
+    )
+
+    results = trainer.fit(
+        datamodule,
+        n_ctx=args.n_ctx,
+        ctx_init=args.ctx_init,
+        template=args.template,
+    )
+
+    for result in results:
+        print(
+            f"Plant: {result.plant} | best epoch: {result.best_epoch} | "
+            f"val acc: {result.best_val_accuracy:.3f} | test acc: {result.test_accuracy:.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ datetime = "^5.5"
 requests = "^2.32.3"
 psutil = "^6.1.0"
 torchdyno = "^0.2.3"
+torch = "^2.4.0"
+torchvision = "^0.19.0"
+open-clip-torch = "^2.24.0"
+pillow = "^11.0.0"
 
 [tool.poetry.group.dev]
 optional = true

--- a/spaceai/data/__init__.py
+++ b/spaceai/data/__init__.py
@@ -1,10 +1,18 @@
 from .anomaly_dataset import AnomalyDataset
+from .esa import ESA, ESAMission, ESAMissions
 from .nasa import NASA
-from .esa import (
-    ESA,
-    ESAMissions,
-    ESAMission,
-)
 from .ops_sat import OPSSAT
+from .plant_datamodule import PlantDataModule, PlantDataModuleConfig
+from .plant_dataset import PlantDataset
 
-__all__ = ["AnomalyDataset", "NASA", "ESA", "ESAMissions", "ESAMission", "OPSSAT"]
+__all__ = [
+    "AnomalyDataset",
+    "ESA",
+    "ESAMission",
+    "ESAMissions",
+    "NASA",
+    "OPSSAT",
+    "PlantDataModule",
+    "PlantDataModuleConfig",
+    "PlantDataset",
+]

--- a/spaceai/data/plant_datamodule.py
+++ b/spaceai/data/plant_datamodule.py
@@ -1,0 +1,214 @@
+"""PyTorch datamodule tailored for the ecoGrow prompt tuning pipeline."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
+
+from torch.utils.data import DataLoader, Dataset
+from torchvision import transforms as T
+
+from .plant_dataset import PlantDataset
+
+
+def _default_transforms(image_size: int) -> Tuple[T.Compose, T.Compose]:
+    train_transform = T.Compose(
+        [
+            T.Resize(image_size, interpolation=T.InterpolationMode.BICUBIC),
+            T.CenterCrop(image_size),
+            T.RandomHorizontalFlip(),
+            T.ToTensor(),
+            T.Normalize(mean=(0.48145466, 0.4578275, 0.40821073), std=(0.26862954, 0.26130258, 0.27577711)),
+        ]
+    )
+
+    eval_transform = T.Compose(
+        [
+            T.Resize(image_size, interpolation=T.InterpolationMode.BICUBIC),
+            T.CenterCrop(image_size),
+            T.ToTensor(),
+            T.Normalize(mean=(0.48145466, 0.4578275, 0.40821073), std=(0.26862954, 0.26130258, 0.27577711)),
+        ]
+    )
+
+    return train_transform, eval_transform
+
+
+@dataclass
+class PlantDataModuleConfig:
+    """Configuration parameters for :class:`PlantDataModule`."""
+
+    data_root: Path
+    prompts_path: Path
+    plant_names: Optional[Iterable[str]] = None
+    batch_size: int = 32
+    num_workers: int = 4
+    image_size: int = 224
+    split_ratio: Tuple[float, float, float] = (0.7, 0.15, 0.15)
+    seed: int = 42
+    segmentation_fns: Optional[Mapping[str, Callable]] = None
+
+
+class PlantDataModule:
+    """Build plant-specific dataloaders for prompt tuning experiments."""
+
+    def __init__(self, config: PlantDataModuleConfig) -> None:
+        self.config = config
+        self.data_root = config.data_root.expanduser().resolve()
+        self.prompts_path = config.prompts_path.expanduser().resolve()
+
+        if not self.data_root.exists():
+            msg = f"Dataset directory '{self.data_root}' does not exist"
+            raise FileNotFoundError(msg)
+
+        with self.prompts_path.open("r", encoding="utf-8") as handle:
+            self.prompts_config: Dict[str, Dict[str, str]] = json.load(handle)
+
+        if config.plant_names is None:
+            plant_names = sorted(self.prompts_config.keys())
+        else:
+            plant_names = list(config.plant_names)
+
+        self.plant_names = plant_names
+        self._train_transform: Optional[Callable] = None
+        self._eval_transform: Optional[Callable] = None
+        self._datasets: Dict[str, Dict[str, Dataset]] = {}
+
+    def setup(
+        self,
+        train_transform: Optional[Callable] = None,
+        eval_transform: Optional[Callable] = None,
+    ) -> None:
+        """Instantiate the datasets for every plant species."""
+
+        if train_transform is None or eval_transform is None:
+            train_transform, eval_transform = _default_transforms(self.config.image_size)
+
+        self._train_transform = train_transform
+        self._eval_transform = eval_transform
+
+        rng = random.Random(self.config.seed)
+
+        for plant in self.plant_names:
+            class_prompts = self.prompts_config.get(plant)
+            if not class_prompts:
+                msg = f"No prompt entries found for plant '{plant}'"
+                raise KeyError(msg)
+
+            class_to_idx = {class_name: idx for idx, class_name in enumerate(class_prompts)}
+            plant_dir = self.data_root / plant
+            if not plant_dir.exists():
+                msg = f"Plant directory '{plant_dir}' does not exist"
+                raise FileNotFoundError(msg)
+
+            segmentation_fn = None
+            if self.config.segmentation_fns is not None:
+                segmentation_fn = self.config.segmentation_fns.get(plant)
+
+            datasets: Dict[str, Dataset] = {}
+
+            split_dirs = {name: plant_dir / name for name in ("train", "val", "test")}
+            if all(path.exists() for path in split_dirs.values()):
+                datasets["train"] = PlantDataset.from_directory(
+                    split_dirs["train"],
+                    class_to_idx,
+                    transform=train_transform,
+                    segmentation_fn=segmentation_fn,
+                )
+                datasets["val"] = PlantDataset.from_directory(
+                    split_dirs["val"],
+                    class_to_idx,
+                    transform=eval_transform,
+                    segmentation_fn=segmentation_fn,
+                )
+                datasets["test"] = PlantDataset.from_directory(
+                    split_dirs["test"],
+                    class_to_idx,
+                    transform=eval_transform,
+                    segmentation_fn=segmentation_fn,
+                )
+            else:
+                base_dataset = PlantDataset.from_directory(
+                    plant_dir,
+                    class_to_idx,
+                    transform=None,
+                    segmentation_fn=segmentation_fn,
+                )
+
+                lengths = self._compute_split_lengths(len(base_dataset))
+                indices = list(range(len(base_dataset)))
+                rng.shuffle(indices)
+
+                split_offsets = [0, lengths[0], lengths[0] + lengths[1], len(base_dataset)]
+                split_indices = {
+                    "train": indices[split_offsets[0] : split_offsets[1]],
+                    "val": indices[split_offsets[1] : split_offsets[2]],
+                    "test": indices[split_offsets[2] : split_offsets[3]],
+                }
+
+                for split_name, idxs in split_indices.items():
+                    split_transform = train_transform if split_name == "train" else eval_transform
+                    datasets[split_name] = PlantDataset(
+                        image_paths=[base_dataset.image_paths[i] for i in idxs],
+                        labels=[base_dataset.labels[i] for i in idxs],
+                        class_names=base_dataset.class_names,
+                        transform=split_transform,
+                        segmentation_fn=base_dataset.segmentation_fn,
+                    )
+
+            self._datasets[plant] = datasets
+
+    def dataloaders(self, plant: str) -> Dict[str, DataLoader]:
+        """Return the train/val/test dataloaders for a given plant."""
+
+        if plant not in self._datasets:
+            msg = "Call setup() before requesting dataloaders"
+            raise RuntimeError(msg)
+
+        datasets = self._datasets[plant]
+        dataloaders: Dict[str, DataLoader] = {}
+        for split_name, dataset in datasets.items():
+            shuffle = split_name == "train"
+            dataloaders[split_name] = DataLoader(
+                dataset,
+                batch_size=self.config.batch_size,
+                shuffle=shuffle,
+                num_workers=self.config.num_workers,
+                pin_memory=True,
+            )
+
+        return dataloaders
+
+    def class_prompts(self, plant: str) -> Dict[str, str]:
+        """Return the prompt dictionary associated with ``plant``."""
+
+        prompts = self.prompts_config.get(plant)
+        if prompts is None:
+            msg = f"Unknown plant '{plant}'"
+            raise KeyError(msg)
+        return prompts
+
+    def plants(self) -> Iterator[str]:
+        """Iterate over the configured plant species."""
+
+        yield from self.plant_names
+
+    def _compute_split_lengths(self, dataset_length: int) -> Tuple[int, int, int]:
+        train_ratio, val_ratio, test_ratio = self.config.split_ratio
+        total = train_ratio + val_ratio + test_ratio
+        if total <= 0:
+            msg = "Split ratios must add up to a positive number"
+            raise ValueError(msg)
+
+        train_len = int(dataset_length * train_ratio / total)
+        val_len = int(dataset_length * val_ratio / total)
+        test_len = dataset_length - train_len - val_len
+        if train_len == 0 or val_len == 0 or test_len == 0:
+            msg = "Dataset too small for the requested split ratios"
+            raise ValueError(msg)
+
+        return train_len, val_len, test_len
+

--- a/spaceai/data/plant_dataset.py
+++ b/spaceai/data/plant_dataset.py
@@ -1,0 +1,165 @@
+"""Dataset utilities for the ecoGrow plant disease recognition project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+def _default_loader(path: Path) -> Image.Image:
+    """Load an image from *path* and convert it to RGB."""
+
+    with Image.open(path) as img:
+        return img.convert("RGB")
+
+
+@dataclass
+class Sample:
+    """A single dataset sample returned by :class:`PlantDataset`.
+
+    Attributes
+    ----------
+    image:
+        The pre-processed PIL image.
+    label:
+        Integer index identifying the target class.
+    class_name:
+        Human readable name of the target class. This is useful when
+        aggregating few-shot results across different plants.
+    path:
+        Path to the original image on disk.
+    """
+
+    image: Image.Image
+    label: int
+    class_name: str
+    path: Path
+
+
+class PlantDataset(Dataset[Tuple[Image.Image, int]]):
+    """A lightweight dataset wrapping plant disease images.
+
+    Parameters
+    ----------
+    image_paths:
+        Sequence of image paths to load.
+    labels:
+        Sequence with the class index associated to every element in
+        ``image_paths``.
+    class_names:
+        Mapping from integer labels to their class names. The index of the
+        list corresponds to the numeric label stored in ``labels``.
+    transform:
+        Optional callable applied to the PIL image. Usually this comes from
+        the OpenCLIP preprocessing utilities.
+    segmentation_fn:
+        Optional callable applied to the PIL image before the transforms in
+        order to isolate the plant from the background.
+    loader:
+        Callable responsible for loading raw images from disk. Defaults to a
+        simple RGB loader based on :mod:`PIL`.
+    """
+
+    def __init__(
+        self,
+        image_paths: Sequence[Path],
+        labels: Sequence[int],
+        class_names: Sequence[str],
+        transform: Optional[Callable[[Image.Image], object]] = None,
+        segmentation_fn: Optional[Callable[[Image.Image], Image.Image]] = None,
+        loader: Callable[[Path], Image.Image] = _default_loader,
+    ) -> None:
+        if len(image_paths) != len(labels):
+            msg = "image_paths and labels must contain the same number of items"
+            raise ValueError(msg)
+
+        self.image_paths: List[Path] = list(image_paths)
+        self.labels: List[int] = list(labels)
+        self.class_names: List[str] = list(class_names)
+        self.transform = transform
+        self.segmentation_fn = segmentation_fn
+        self.loader = loader
+
+    def __len__(self) -> int:  # noqa: D401 - standard Dataset API
+        """Return the number of available samples."""
+
+        return len(self.image_paths)
+
+    def __getitem__(self, index: int) -> Tuple[object, int]:  # noqa: D401
+        """Return the processed sample at ``index``.
+
+        The returned tuple contains the transformed image and the
+        corresponding class index. The image can either be a PIL image or a
+        tensor depending on the transform passed at construction time.
+        """
+
+        path = self.image_paths[index]
+        label = self.labels[index]
+
+        image = self.loader(path)
+        if self.segmentation_fn is not None:
+            image = self.segmentation_fn(image)
+
+        if self.transform is not None:
+            image = self.transform(image)
+
+        return image, label
+
+    @classmethod
+    def from_directory(
+        cls,
+        root: Path,
+        class_to_idx: Dict[str, int],
+        transform: Optional[Callable[[Image.Image], object]] = None,
+        segmentation_fn: Optional[Callable[[Image.Image], Image.Image]] = None,
+        extensions: Optional[Iterable[str]] = None,
+    ) -> "PlantDataset":
+        """Create a dataset by scanning a directory tree.
+
+        The directory must contain one sub-directory per class. Each
+        sub-directory is expected to host the images for that specific class.
+        The resulting dataset keeps the alphabetical order of classes unless
+        ``class_to_idx`` specifies a custom mapping.
+        """
+
+        if extensions is None:
+            extensions = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+        else:
+            extensions = {ext.lower() for ext in extensions}
+
+        root = root.expanduser().resolve()
+        if not root.exists():
+            msg = f"Plant directory '{root}' does not exist"
+            raise FileNotFoundError(msg)
+
+        image_paths: List[Path] = []
+        labels: List[int] = []
+        class_names: List[str] = [""] * len(class_to_idx)
+
+        for class_name, class_idx in sorted(class_to_idx.items(), key=lambda x: x[1]):
+            class_dir = root / class_name
+            if not class_dir.exists():
+                continue
+
+            class_names[class_idx] = class_name
+            for path in sorted(class_dir.rglob("*")):
+                if path.suffix.lower() in extensions and path.is_file():
+                    image_paths.append(path)
+                    labels.append(class_idx)
+
+        if not image_paths:
+            msg = f"No images found inside '{root}'"
+            raise RuntimeError(msg)
+
+        return cls(
+            image_paths=image_paths,
+            labels=labels,
+            class_names=class_names,
+            transform=transform,
+            segmentation_fn=segmentation_fn,
+        )
+

--- a/spaceai/models/__init__.py
+++ b/spaceai/models/__init__.py
@@ -1,6 +1,3 @@
-from . import (
-    predictors,
-    anomaly,
-)
+from . import anomaly, predictors, prompt_learning
 
-__all__ = ["predictors", "anomaly"]
+__all__ = ["anomaly", "predictors", "prompt_learning"]

--- a/spaceai/models/prompt_learning/__init__.py
+++ b/spaceai/models/prompt_learning/__init__.py
@@ -1,0 +1,11 @@
+"""ecoGrow prompt learning utilities based on OpenCLIP."""
+
+from .prompt_learner import PromptLearnerOpenCLIP
+from .trainer import PromptTuningTrainer, PromptTuningResult
+
+__all__ = [
+    "PromptLearnerOpenCLIP",
+    "PromptTuningTrainer",
+    "PromptTuningResult",
+]
+

--- a/spaceai/models/prompt_learning/prompt_learner.py
+++ b/spaceai/models/prompt_learning/prompt_learner.py
@@ -1,0 +1,144 @@
+"""Prompt learner module inspired by CoOp for the ecoGrow project."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+import open_clip
+
+
+class PromptLearnerOpenCLIP(nn.Module):
+    """Learn context vectors to adapt OpenCLIP prompts.
+
+    Parameters
+    ----------
+    clip_model:
+        The OpenCLIP model whose text tower is leveraged to encode prompts.
+        The caller is expected to keep the backbone in evaluation mode and to
+        freeze all parameters before instantiating the learner.
+    class_prompts:
+        Mapping between class identifiers and their textual descriptions. The
+        insertion order is preserved and defines the class index order.
+    n_ctx:
+        Number of learnable context tokens prepended to each class prompt.
+    ctx_init:
+        Optional string used to initialise the context vectors using the
+        pre-trained CLIP token embeddings. When omitted, the contexts are
+        sampled from a normal distribution with a standard deviation of 0.02.
+    template:
+        Template string where ``{description}`` is replaced with the class
+        description. Defaults to "a photo of {description}".
+    device:
+        Optional device identifier used to host the learnable parameters.
+    """
+
+    def __init__(
+        self,
+        clip_model: nn.Module,
+        class_prompts: Dict[str, str],
+        n_ctx: int = 16,
+        ctx_init: Optional[str] = None,
+        template: str = "a photo of {description}",
+        device: Optional[torch.device | str] = None,
+    ) -> None:
+        super().__init__()
+
+        if n_ctx <= 0:
+            msg = "n_ctx must be a positive integer"
+            raise ValueError(msg)
+
+        self.clip_model = clip_model
+        self.n_ctx = n_ctx
+        self.template = template
+        self.device = device or next(clip_model.parameters()).device
+
+        self.class_names: List[str] = list(class_prompts.keys())
+        self.class_descriptions: List[str] = list(class_prompts.values())
+        if not self.class_names:
+            msg = "class_prompts cannot be empty"
+            raise ValueError(msg)
+
+        with torch.no_grad():
+            token_embedding = getattr(self.clip_model, "token_embedding")
+            if token_embedding is None:
+                msg = "The provided clip_model does not expose token_embedding"
+                raise AttributeError(msg)
+            embed_dim = token_embedding.weight.shape[1]
+            embedding_dtype = token_embedding.weight.dtype
+
+        initial_context = self._build_initial_context(ctx_init, embed_dim, embedding_dtype)
+        self.ctx = nn.Parameter(initial_context)
+
+        prompt_texts = [self._build_prompt_text(description) for description in self.class_descriptions]
+        self.register_buffer("tokenized_prompts", open_clip.tokenize(prompt_texts))
+
+    def forward(self, image_features: torch.Tensor) -> torch.Tensor:
+        """Compute image-text logits for the provided ``image_features``."""
+
+        text_features = self.encode_text()
+        image_features = F.normalize(image_features, dim=-1)
+        text_features = F.normalize(text_features, dim=-1)
+
+        logit_scale = self.clip_model.logit_scale.exp()
+        return logit_scale * image_features @ text_features.t()
+
+    def encode_text(self) -> torch.Tensor:
+        """Encode the class prompts with the current context vectors."""
+
+        tokenized = self.tokenized_prompts.to(self.device)
+        embeddings = self.clip_model.token_embedding(tokenized).to(self.ctx.dtype)
+
+        ctx = self.ctx.unsqueeze(0).expand(tokenized.size(0), -1, -1)
+        embeddings[:, 1 : 1 + self.n_ctx, :] = ctx
+
+        positional_embedding = self.clip_model.positional_embedding.to(embeddings.dtype)
+        x = embeddings + positional_embedding
+        x = x.permute(1, 0, 2)
+        attn_mask = getattr(self.clip_model, "attn_mask", None)
+        if attn_mask is not None:
+            x = self.clip_model.transformer(x, attn_mask=attn_mask)
+        else:
+            x = self.clip_model.transformer(x)
+        x = x.permute(1, 0, 2)
+        x = self.clip_model.ln_final(x)
+
+        eos_token = tokenized.argmax(dim=-1)
+        x = x[torch.arange(x.shape[0]), eos_token]
+        text_features = x @ self.clip_model.text_projection
+
+        return text_features
+
+    def _build_initial_context(
+        self,
+        ctx_init: Optional[str],
+        embed_dim: int,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        if ctx_init:
+            tokenized = open_clip.tokenize([ctx_init]).to(self.device)
+            with torch.no_grad():
+                embeddings = self.clip_model.token_embedding(tokenized)[0, 1 : 1 + self.n_ctx]
+            if embeddings.shape[0] < self.n_ctx:
+                msg = "ctx_init is too short for the requested number of context tokens"
+                raise ValueError(msg)
+            ctx_vectors = embeddings[: self.n_ctx]
+        else:
+            ctx_vectors = torch.randn(self.n_ctx, embed_dim, device=self.device, dtype=dtype) * 0.02
+
+        return ctx_vectors.to(self.device, dtype=dtype)
+
+    def _build_prompt_text(self, description: str) -> str:
+        context_placeholder = " ".join(["X"] * self.n_ctx)
+        prompt = self.template.format(description=description)
+        return f"{context_placeholder} {prompt}".strip()
+
+    @property
+    def class_prompts(self) -> Dict[str, str]:
+        """Return the mapping between class names and their descriptions."""
+
+        return dict(zip(self.class_names, self.class_descriptions, strict=True))
+

--- a/spaceai/models/prompt_learning/trainer.py
+++ b/spaceai/models/prompt_learning/trainer.py
@@ -1,0 +1,161 @@
+"""Training utilities for ecoGrow prompt tuning experiments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from ...data.plant_datamodule import PlantDataModule
+from .prompt_learner import PromptLearnerOpenCLIP
+
+
+@dataclass
+class PromptTuningResult:
+    """Container for the training statistics of a single plant."""
+
+    plant: str
+    best_epoch: int
+    best_val_accuracy: float
+    test_accuracy: float
+    history: List[Dict[str, float]] = field(default_factory=list)
+
+
+class PromptTuningTrainer:
+    """Simple prompt tuning loop that freezes the CLIP backbone."""
+
+    def __init__(
+        self,
+        clip_model: nn.Module,
+        preprocess_train: Callable,
+        preprocess_val: Callable,
+        device: Optional[torch.device | str] = None,
+        epochs: int = 20,
+        lr: float = 5e-3,
+        weight_decay: float = 0.0,
+        log_every: int = 10,
+    ) -> None:
+        self.clip_model = clip_model.eval()
+        for param in self.clip_model.parameters():
+            param.requires_grad_(False)
+
+        self.preprocess_train = preprocess_train
+        self.preprocess_val = preprocess_val
+        self.device = torch.device(device) if device is not None else next(clip_model.parameters()).device
+        self.epochs = epochs
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.log_every = log_every
+
+    def fit(
+        self,
+        data_module: PlantDataModule,
+        n_ctx: int = 16,
+        ctx_init: Optional[str] = None,
+        template: str = "a photo of {description}",
+    ) -> List[PromptTuningResult]:
+        """Train a prompt learner for every plant in ``data_module``."""
+
+        data_module.setup(self.preprocess_train, self.preprocess_val)
+        results: List[PromptTuningResult] = []
+
+        for plant in data_module.plants():
+            class_prompts = data_module.class_prompts(plant)
+            learner = PromptLearnerOpenCLIP(
+                self.clip_model,
+                class_prompts=class_prompts,
+                n_ctx=n_ctx,
+                ctx_init=ctx_init,
+                template=template,
+                device=self.device,
+            ).to(self.device)
+
+            optimizer = torch.optim.AdamW(learner.parameters(), lr=self.lr, weight_decay=self.weight_decay)
+            dataloaders = data_module.dataloaders(plant)
+
+            history: List[Dict[str, float]] = []
+            best_val_acc = 0.0
+            best_epoch = 0
+            best_state = None
+
+            for epoch in range(1, self.epochs + 1):
+                train_loss = self._train_one_epoch(learner, optimizer, dataloaders["train"], epoch)
+                val_acc = self._evaluate(learner, dataloaders.get("val"))
+
+                history.append({"epoch": float(epoch), "train_loss": train_loss, "val_accuracy": val_acc})
+
+                if val_acc >= best_val_acc:
+                    best_val_acc = val_acc
+                    best_epoch = epoch
+                    best_state = {k: v.detach().cpu() for k, v in learner.state_dict().items()}
+
+            if best_state is not None:
+                learner.load_state_dict(best_state)
+
+            test_acc = self._evaluate(learner, dataloaders.get("test"))
+            results.append(
+                PromptTuningResult(
+                    plant=plant,
+                    best_epoch=best_epoch,
+                    best_val_accuracy=best_val_acc,
+                    test_accuracy=test_acc,
+                    history=history,
+                )
+            )
+
+        return results
+
+    def _train_one_epoch(self, learner: PromptLearnerOpenCLIP, optimizer, dataloader, epoch: int) -> float:
+        learner.train()
+        total_loss = 0.0
+        total_samples = 0
+
+        for step, (images, labels) in enumerate(dataloader, start=1):
+            images = images.to(self.device, non_blocking=True)
+            labels = labels.to(self.device, non_blocking=True)
+
+            with torch.no_grad():
+                image_features = self.clip_model.encode_image(images)
+
+            logits = learner(image_features)
+            loss = F.cross_entropy(logits, labels)
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            batch_size = labels.size(0)
+            total_loss += loss.item() * batch_size
+            total_samples += batch_size
+
+            if step % self.log_every == 0:
+                current_loss = total_loss / total_samples if total_samples else 0.0
+                print(f"[Epoch {epoch:03d}] step {step:04d} - loss: {current_loss:.4f}")
+
+        return total_loss / max(total_samples, 1)
+
+    @torch.no_grad()
+    def _evaluate(self, learner: PromptLearnerOpenCLIP, dataloader) -> float:
+        if dataloader is None:
+            return 0.0
+
+        learner.eval()
+        correct = 0
+        total = 0
+
+        for images, labels in dataloader:
+            images = images.to(self.device, non_blocking=True)
+            labels = labels.to(self.device, non_blocking=True)
+
+            image_features = self.clip_model.encode_image(images)
+            logits = learner(image_features)
+            predictions = logits.argmax(dim=-1)
+
+            correct += (predictions == labels).sum().item()
+            total += labels.size(0)
+
+        return correct / total if total else 0.0
+


### PR DESCRIPTION
## Summary
- add core dependencies required for OpenCLIP-based prompt tuning
- implement reusable plant dataset/datamodule utilities for ecoGrow experiments
- introduce prompt learner, trainer, and CLI entry-point to run the pipeline end-to-end

## Testing
- python -m compileall spaceai
- python -m compileall examples/ecoGrow_prompt_tuning.py

------
https://chatgpt.com/codex/tasks/task_e_68f387dd17c48328921cd6f3cb2e08d9